### PR TITLE
update max room count for android

### DIFF
--- a/projects/bolg/server/.gitignore
+++ b/projects/bolg/server/.gitignore
@@ -1,2 +1,3 @@
 apiserver.exe
 apiserver
+bolg.log

--- a/projects/bolg/server/cmd/apiserver/apiserver.go
+++ b/projects/bolg/server/cmd/apiserver/apiserver.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net"
+	"os"
 
 	"github.com/bolg-developers/x/projects/bolg/server/pb"
 	"github.com/bolg-developers/x/projects/bolg/server/pkg/bolg"
@@ -10,6 +11,9 @@ import (
 )
 
 func main() {
+	logfile, err := os.OpenFile("./bolg.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	log.SetOutput(logfile)
+
 	port, err := net.Listen("tcp", ":50051")
 	if err != nil {
 		panic(err)

--- a/projects/bolg/server/pkg/bolg/database_memory.go
+++ b/projects/bolg/server/pkg/bolg/database_memory.go
@@ -3,6 +3,7 @@ package bolg
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 )
 
@@ -28,6 +29,7 @@ func (db *memoryRoomDatabase) Create(r *Room) error {
 	}
 	db.roomMap[r.Id] = r
 	db.playersMap[r.Id] = make(Players, 0, maxPlayer)
+	log.Println("Created room:", len(db.roomMap))
 	return nil
 }
 

--- a/projects/bolg/server/pkg/bolg/types.go
+++ b/projects/bolg/server/pkg/bolg/types.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	maxPlayer = 16
-	maxRoom   = 30
+	maxRoom   = 1000
 	initHP    = 100
 )
 


### PR DESCRIPTION
<!-- 本日もご苦労様です (｡•ω- ｡) ⌒♡ --> 

**このPRはどういったものですか / なぜこのPRは必要になるのですか**:
<!--
少なくともどちらひとつの質問には回答してください。
-->
一台のサーバーで生成できるルーム数の上限を30から1000に引き上げました。
release-v1には部屋を自動削除する機能は入れていないかつ、AndroidがAPIをバシバシしばいてくれているので、とりあえずの対策として上限を引き上げています。

**レビュワーに留意しておいてほしいことはありますか**:
SM。

@hsgw-yuta 
[これ](https://app.asana.com/0/1150949978164532/1151861469392393/f
)に関するプルリクです。対応しました。

**なにか参照すべきものはありますか**:
<!--
design docなどを書いているならばそのURLを書いてください。
-->

<!-- いつもしっかり以下を行なって頂き、助かってます( ⁎ᵕᴗᵕ⁎ )
* Reviewerを指定する
* Assigneeを指定する
* xラベルをつける
* kindラベルをつける
* teamラベルをつける
-->

